### PR TITLE
update `dataCreate` to return true or throw error

### DIFF
--- a/db/dataAccess.js
+++ b/db/dataAccess.js
@@ -51,8 +51,9 @@ async function dataCreate (document, opts = config) {
     ? await col.insertMany(document)
     : await col.insertOne(document)
   await client.close()
+  const resultOk = result.result.ok === 1
 
-  return result
+  return resultOk
 }
 
 /**
@@ -129,12 +130,12 @@ async function dataUpdate (query, updates, opts = config) {
 
   const numMatches = await countMatching(query, opts)
 
-  if (numMatches > 1) {
-    await col.updateMany(query, updates)
-  } else {
-    await col.updateOne(query, updates)
-  }
+  const result = (numMatches > 1)
+    ? await col.updateMany(query, updates)
+    : await col.updateOne(query, updates)
+
   await client.close()
+  return result
 }
 
 /**

--- a/tests/01-db/20-dataCreate.test.js
+++ b/tests/01-db/20-dataCreate.test.js
@@ -9,7 +9,8 @@ async function testDataCreate (testName, document, opts) {
     const queryDocument = Array.isArray(document)
       ? { test: document[0].test }
       : { test: document.test }
-    await da.dataCreate(document, opts)
+    const insertOk = await da.dataCreate(document, opts)
+    assert.ok(insertOk)
     const results = await da.dataRead(queryDocument, opts)
     for (const result of results) {
       assert.strictEqual(queryDocument.test, result.test)
@@ -22,7 +23,7 @@ async function testDataCreate (testName, document, opts) {
 }
 
 (async () => {
-  await testDataCreate(
+  testDataCreate(
     'Insert one document',
     { test: 'This is only a test.' },
     {
@@ -30,7 +31,7 @@ async function testDataCreate (testName, document, opts) {
       colName: 'test'
     }
   )
-  await testDataCreate(
+  testDataCreate(
     'Insert many documents',
     [
       { test: 'This is one of 4 documents' },


### PR DESCRIPTION
Apparently the spec requires `dataCreate` to return true on a successful
insert. This PR implements that functionality. It should still throw an
error when things go horribly awry.