### PR TITLE
fixes update controller and service

### DIFF
--- a/controllers/index.js
+++ b/controllers/index.js
@@ -25,10 +25,11 @@ async function readController (req, res, next) {
 }
 
 async function updateController (req, res, next) {
-  if (Object.entries(req.query).length === 2) {
-    const [query, newValue] = Object.entries(req.query)
+  if (Object.entries(req.query).length >= 2) {
+    const queryPair = Object.entries(req.query)[0]
+    const updatePairs = Object.entries(req.query).slice(1)
     try {
-      await services.UpdateService(query, newValue)
+      await services.updateService(queryPair, updatePairs)
       res.sendStatus(200)
     } catch (err) {
       console.log(err)

--- a/services/index.js
+++ b/services/index.js
@@ -35,8 +35,11 @@ async function readService (query) {
  * @param {Object} update - MongoDB document specifying the update to perform
  * @returns {bool} - true if update was successful, else returns an error.
  */
-async function updateService (query, update) {
-  await db.dataUpdate(query, update)
+async function updateService (queryPair, updatePairs) {
+  const query = { [queryPair[0]]: queryPair[1] }
+  const updateDoc = {}
+  updatePairs.forEach((pair) => { updateDoc[pair[0]] = pair[1] })
+  await db.dataUpdate(query, { $set: updateDoc })
 }
 
 /**

--- a/services/index.js
+++ b/services/index.js
@@ -32,8 +32,8 @@ async function readService (query) {
  * in the project's config.json.
  *
  * @param {Object} query - the MongoDB query matching documents to update
- * @param {Object} update - MongoDB document specifying the update to perform
- * @returns {bool} - true if update was successful, else returns an error.
+ * @param {Array[]} updatePairs - an array of 1--* 2-value arrays specifying
+ *        fields to update and their new values
  */
 async function updateService (queryPair, updatePairs) {
   const query = { [queryPair[0]]: queryPair[1] }


### PR DESCRIPTION
Update ops were broken because I hadn't realized I was passing arrays
instead of key-value objects. This PR fixes that. Now,
`updateController` passes a single 2-value array for the query pair and
an array of 2-value arrays, one for each key-value pair to update. These
get processed into objects on the service layer. As I understand it,
this effectively separates the Express framework logic dealing with the
request from the business logic of creating query and update objects to
pass to the data access layer and, eventually, the MongoDB driver.