### PR TITLE
add logic to print useful message on empty search

### DIFF
--- a/controllers/index.js
+++ b/controllers/index.js
@@ -17,7 +17,11 @@ async function readController (req, res, next) {
   const query = req.query
   try {
     const result = await services.readService(query)
-    res.send(JSON.stringify(result, null, 2))
+    if (typeof result !== 'undefined') {
+      res.send(JSON.stringify(result, null, 2))
+    } else {
+      res.send('Search returned no results.')
+    }
   } catch (err) {
     console.log(err)
     res.sendStatus(500)

--- a/tests/02-api/curls.sh
+++ b/tests/02-api/curls.sh
@@ -18,3 +18,6 @@ echo ""
 
 curl 'http://localhost:3000/api/delete?id=10011-2017-TEST'
 echo ""
+
+curl 'http://localhost:3000/api/read?business_name=ACME+TEST+INC.'
+echo ""


### PR DESCRIPTION
The original read controller sent an empty response for searches that
match no documents. This update fixes that, because that behavior is
useless and unhelpful. Instead, it returns a message indicating that the
search returned no results. Probably, if this API had to interact with a
frontend team, I'd do something more useful, but this works for the
purpose of this project.