### PR TITLE
added usage message

### DIFF
--- a/bin/insert-stock.js
+++ b/bin/insert-stock.js
@@ -23,6 +23,10 @@ async function readUserInput (argv) {
 
 ;(async () => {
   const argv = parseArgs(process.argv.slice(2))
+  if (argv.help) {
+    console.log('Usage: insert-stock.js [-f <file>]')
+    process.exit(0)
+  }
   try {
     const result = await readUserInput(argv)
     console.log(result)


### PR DESCRIPTION
Print a help message with the `--help` flag. I've written enough scripts that get used once in a blue moon to know how helpful this is; I can't explain why I didn't include it in the first place.