### PR TITLE
Fixes issues inserting docs with $oid or $date

### DIFF
--- a/bin/insert-stock.js
+++ b/bin/insert-stock.js
@@ -21,8 +21,7 @@ async function readUserInput (argv) {
   }
 }
 
-;(async () => {
-  const argv = parseArgs(process.argv.slice(2))
+async function insertNewStock (argv) {
   if (argv.help) {
     console.log('Usage: insert-stock.js [-f <file>]')
     process.exit(0)
@@ -36,4 +35,9 @@ async function readUserInput (argv) {
       ? console.log('Invalid JSON. Aborting.')
       : console.log(err)
   }
+}
+
+;(async () => {
+  const argv = parseArgs(process.argv.slice(2))
+  insertNewStock(argv)
 })()

--- a/util/jsonUtils.js
+++ b/util/jsonUtils.js
@@ -1,5 +1,7 @@
 #!/usr/bin/env node
 
+const mongo = require('mongodb')
+
 /**
  * Reads a readable stream and transforms it into a string
  * @param {Object} stream - a readable stream
@@ -15,16 +17,28 @@ function streamToString (stream) {
 }
 
 /**
- * Parses a JSON stream into a native object
+ * Parses a JSON stream into a native object representation of a MongoDB doc
  * @param {Object} stream - a readable stream
  * @returns {Object} - the object parsed from the stream
  */
-async function jsonStreamToObj (stream) {
+async function jsonStreamToMongoDoc (stream) {
   const jsonString = await streamToString(stream)
-  return JSON.parse(jsonString)
+  const mongoObj = JSON.parse(jsonString)
+  for (const field in mongoObj) {
+    if (typeof mongoObj[field] === 'object') {
+      for (const fieldType in mongoObj[field]) {
+        if (fieldType === '$oid') {
+          mongoObj[field] = new mongo.ObjectID(mongoObj[field][fieldType])
+        } else if (fieldType === '$date') {
+          mongoObj[field] = new Date(mongoObj[field][fieldType])
+        }
+      }
+    }
+  }
+  return mongoObj
 }
 
 module.exports = {
   streamToString: streamToString,
-  jsonStreamToObj: jsonStreamToObj
+  jsonStreamToMongoDoc: jsonStreamToMongoDoc
 }


### PR DESCRIPTION
This PR fixes an issue with Mongo throwing errors about `$oid` and
`$date` fields. Instead, `jsonStreamToMongoDoc` (formerly
`jsonStreamToObj`) scans the object for any of these fields (which, I
assume, come from MongoDB's shell/import query dialect). How it ever
worked last night, I'll never know, but it seems to work now.