### PR TITLE
Implemented utility to delete by ticker

### DIFF
--- a/bin/cli-utils.js
+++ b/bin/cli-utils.js
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+
+const rl = require('readline-sync')
+
+async function getTickerString (argv) {
+  let ticker = 'TEST'
+  if (Object.prototype.hasOwnProperty.call(argv, 't')) {
+    ticker = argv.t
+    return ticker
+  } else {
+    ticker = rl.question('Ticker: ')
+    return ticker
+  }
+}
+
+async function getUpdatedVolume (argv) {
+  let volume = 6
+  if (Object.prototype.hasOwnProperty.call(argv, 'v')) {
+    volume = argv.v
+    return volume
+  } else {
+    volume = rl.question('Volume: ')
+    return parseInt(volume)
+  }
+}
+
+module.exports = {
+  getTickerString: getTickerString,
+  getUpdatedVolume: getUpdatedVolume
+}

--- a/bin/delete-ticker.js
+++ b/bin/delete-ticker.js
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+
+const parseArgs = require('minimist')
+const { getTickerString } = require('./cli-utils')
+const db = require('../db')
+
+async function deleteStockByTicker (argv) {
+  let ticker
+  try {
+    ticker = await getTickerString(argv)
+  } catch (err) {
+    console.log(err)
+    process.exit(1)
+  }
+
+  const query = { Ticker: ticker }
+
+  try {
+    const result = await db.dataDelete(query)
+    if (result.result.n === 1) {
+      console.log(`Deleted stock record for Ticker ${ticker}`)
+    } else if (result.result.n > 1) {
+      console.log(
+        `Deleted more than one record for ${ticker}. You may want to check ` +
+          'the database for inconsistencies.'
+      )
+    } else {
+      console.log('No matching record found')
+    }
+  } catch (err) {
+    console.log('Something went wrong')
+    console.log(err)
+  }
+}
+
+;(async () => {
+  const argv = parseArgs(process.argv.slice(2))
+  deleteStockByTicker(argv)
+})()


### PR DESCRIPTION
This PR implements a command line utility to delete stocks by ticker
symbol. In doing so, it pulls out prompt logic from `update-volume.js`
into a separate `cli-utils` file, which isn't quite generic enough for
me to include it in `utils`. Also, everything broke while I was writing
this, so hopefully this is in the right place.