### PR TITLE
Fix update-volume.js to use external prompts

### DIFF
--- a/bin/update-volume.js
+++ b/bin/update-volume.js
@@ -1,30 +1,8 @@
 #!/usr/bin/env node
 
 const parseArgs = require('minimist')
-const rl = require('readline-sync')
+const { getTickerString, getUpdatedVolume } = require('./cli-utils')
 const db = require('../db')
-
-async function getTickerString (argv) {
-  let ticker = 'TEST'
-  if (Object.prototype.hasOwnProperty.call(argv, 't')) {
-    ticker = argv.t
-    return ticker
-  } else {
-    ticker = rl.question('Ticker: ')
-    return ticker
-  }
-}
-
-async function getUpdatedVolume (argv) {
-  let volume = 6
-  if (Object.prototype.hasOwnProperty.call(argv, 'v')) {
-    volume = argv.v
-    return volume
-  } else {
-    volume = rl.question('Volume: ')
-    return parseInt(volume)
-  }
-}
 
 async function updateStockVolume (argv) {
   if (argv.help) {
@@ -51,9 +29,19 @@ async function updateStockVolume (argv) {
     $set: { Volume: volume }
   }
 
-  db.dataUpdate(query, update)
-
-  console.log(`Ticker: ${ticker} Volume: ${volume}`)
+  try {
+    const result = await db.dataUpdate(query, update)
+    if (result.result.nModified > 0) {
+      console.log(`Updated Ticker: ${ticker} Volume: ${volume}`)
+    } else if (result.result.n > 0) {
+      console.log('No results modified')
+    } else {
+      console.log('No matching results')
+    }
+  } catch (err) {
+    console.log('Something went wrong')
+    console.log(err)
+  }
 }
 
 ;(async () => {


### PR DESCRIPTION
This PR fixes update-volume.js to use the external prompts pulled from
the file in the last commit... which maybe should have been done in that
branch? I'm so confused. If I'm lucky, some of this will work when I'm
done...